### PR TITLE
fix(security): bump addressable to 2.9.0 in Example Gemfile

### DIFF
--- a/Example/Gemfile
+++ b/Example/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'cocoapods'
 
 gem 'fastlane'
+gem 'addressable', '>= 2.9.0'
 gem "rexml", ">= 3.3.9"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')

--- a/Example/Gemfile.lock
+++ b/Example/Gemfile.lock
@@ -15,8 +15,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
@@ -283,8 +283,10 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux-gnu
 
 DEPENDENCIES
+  addressable (>= 2.9.0)
   cocoapods
   fastlane
   fastlane-plugin-sentry


### PR DESCRIPTION
<img width="1326" height="61" alt="image" src="https://github.com/user-attachments/assets/fd0a3827-9c5d-4c16-bf8c-a6cc2ae6b9ca" />
source: https://github.com/CrowdPlay-Inc/crowdplay_ios_sdk/security/dependabot/14